### PR TITLE
GitHub action manual dispatch

### DIFF
--- a/.github/workflows/docker-build-release.yml
+++ b/.github/workflows/docker-build-release.yml
@@ -8,8 +8,11 @@ on:
   push:
     branches:
       - master
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version_name:
+        description: 'Version name for the test release (e.g., 1.0.0).'
+        required: true
 
 env:
   APP_NAME: bacnet-server-c
@@ -22,11 +25,10 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs:
-      shouldBuild: ${{ steps.context.outputs.decision_build }}
-      isRelease: ${{ steps.context.outputs.isTag }}
-      sha: ${{ steps.context.outputs.commitId }}
-      version: ${{ steps.context.outputs.version }}
-      fqn: ${{ env.APP_NAME }}-${{ steps.context.outputs.version }}-${{ steps.context.outputs.shortCommitId }}
+      isRelease: ${{ steps.check_release.outputs.is_release }}
+      sha: ${{ github.sha }}
+      version: ${{ steps.extract_version.outputs.version }}
+      fqn: ${{ env.APP_NAME }}-${{ steps.extract_version.outputs.version }}-${{ steps.short_commit.outputs.short_commit }}
 
     steps:
       - uses: actions/checkout@v2
@@ -43,19 +45,49 @@ jobs:
           gpg-private-key: ${{ secrets.NUBEIO_CI_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.NUBEIO_CI_GPG_PASSPHARSE }}
 
-      - name: Project context
-        id: context
-        uses: zero88/gh-project-context@v1
-        with:
-          dry: false
-          mustSign: true
-          defaultBranch: master
+      - name: Extract Version
+        id: extract_version
+        run: |
+          VERSION="0.0.0"
+          
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # Use the provided version name from workflow dispatch input
+            VERSION="${{ github.event.inputs.version_name }}"
+          elif [[ "${{ github.event.pull_request.merged }}" == "true" ]]; then
+            # For pull requests, check if merging into master from a release branch
+            HEAD_BRANCH="${{ github.event.pull_request.head.ref }}"
+            if [[ "${HEAD_BRANCH}" == "release/"* ]]; then
+              VERSION="${HEAD_BRANCH#release/}"
+            fi
+          fi
+          echo "::set-output name=version::${VERSION}"
+          echo "Version: ${VERSION}"
+          echo "pull_request.head.ref: ${{ github.event.pull_request.head.ref }}"
+          echo "github.event.pull_request.merged: ${{ github.event.pull_request.merged }}"
+
+      - name: Check if Release
+        id: check_release
+        run: |
+          IS_RELEASE="false"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            IS_RELEASE="true"
+          elif [[ "${{ github.event.pull_request.merged }}" == "true" && "${{ github.event.pull_request.head.ref }}" == "release/"* ]]; then
+            IS_RELEASE="true"
+          fi
+          echo "::set-output name=is_release::${IS_RELEASE}"
+          echo "Is Release: ${IS_RELEASE}"
+
+      - name: Get Short Commit ID
+        id: short_commit
+        run: |
+          SHORT_COMMIT=$(git rev-parse --short=7 HEAD)
+          echo "::set-output name=short_commit::$SHORT_COMMIT"
+          echo "Short Commit ID: $SHORT_COMMIT"
 
   build:
 
     runs-on: ubuntu-latest
     needs: context
-    if: needs.context.outputs.shouldBuild == 'true'
     services:
       registry:
         image: zero88/gh-registry:latest
@@ -138,6 +170,7 @@ jobs:
           password: ${{ secrets.NUBEIO_CI_GITHUB_PACKAGES_PAT }}
 
       - name: Create Release
+        if: ${{ needs.context.outputs.isRelease == 'true' }}
         uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -148,4 +181,3 @@ jobs:
           prerelease: false
           files: |
             /tmp/zip/${{ needs.context.outputs.fqn }}.*.zip
-


### PR DESCRIPTION
### Summary

- It includes a manual build trigger option. Users can create a temporary `0.0.0` version (or any version they want) by selecting the desired branch. After testing, we can delete this release. This method facilitates testing without requiring local Docker builds.

https://github.com/NubeIO/driver-bacnet/assets/6800775/50fb489a-e3fe-4d3b-8632-bf1e2bee33de

